### PR TITLE
Allow limiting the maximum line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ line.toString();
 // This is the first line of the file
 ```
 
+## Maximum Line Length
+
+You can limit the maximum line length. When the specified length is reached while reading a line, the buffer will be returned as a new line just like when a line break was encountered:
+
+```js
+// If original lines are longer than 255 characters, an artificial line break
+// will be enforced after each 255 characters reached on a single line. More
+// then original lines will be returned by the generator then.
+var file = readlines(fd, stats.size, undefined, undefined, 255);
+for (let line of readlines(fd, fileSize)) {
+  console.log(line.toString());
+}
+```
+
+You can change the maximum line length for each generated line. If you do not specify the maximum length, when you read the next line, the original maximum line length passed to `readlines` will be used:
+
+```js
+// Lines will not be longer than 255 characters by default.
+var file = readlines(fd, stats.size, undefined, undefined, 255);
+var line = file.next(); // 255 characters maximum
+line = file.next(127);  // 127 characters maximum
+line = file.next();     // 255 characters maximum again
+```
+
+*Note:* The very first generation (call to the `next` method) cannot accept an alternative maximum line length. It will always use the default value passed to `readlines`. First the following calls to `next` allow to specify alternative values. This is caused by the nature of JavaScript generators, which obtain the value from `yield` [first when when resuming the generation](https://stackoverflow.com/a/37355045/623816).
+
 ## Simplified API
 
 Also you can use the simplified version of `readlines`:
@@ -86,16 +112,19 @@ Compatibility
 Documentation
 -------------
 
-#### readlines (fd, filesize, bufferSize=64\*1024, position=0)
+#### readlines (fd, filesize, bufferSize=64\*1024, position=0, maxLineLength=Infinity)
 
  * fd {Number} The file descriptor
  * filesize {Number} The size of the file in bytes
  * bufferSize {Number} The size of the buffer in bytes, default: 64\*1024
  * position {Number} The position where to start reading the file in bytes, default: 0
+ * maxLineLength {Number} The length to stop reading at if no line break has been reached, default: Infinity
 
-#### readlines.fromFile (filename)
+#### readlines.fromFile (filename, bufferSize=64\*1024, maxLineLength=Infinity)
 
  * filename {string} Name of input file
+ * bufferSize {Number} The size of the buffer in bytes, default: 64\*1024
+ * maxLineLength {Number} The length to stop reading at if no line break has been reached, default: Infinity
 
 Testing
 -------

--- a/tests-simplified.js
+++ b/tests-simplified.js
@@ -74,7 +74,7 @@ describe('The empty file with simplified API', function() {
 describe('The multibyte file with simplified API', function() {
   it('should return 4 lines', function() {
     const lines = [];
-    for (let line of readlines.fromFile('./test_data/multibyte_file.txt', 'r')) {
+    for (let line of readlines.fromFile('./test_data/multibyte_file.txt', 1)) {
       lines.push(line);
     }
 
@@ -85,7 +85,7 @@ describe('The multibyte file with simplified API', function() {
 describe('The multibyte windos file with simplified API', function() {
   it('should return 4 lines', function() {
     const lines = [];
-    for (let line of readlines.fromFile('./test_data/multibyte_windos_file.txt')) {
+    for (let line of readlines.fromFile('./test_data/multibyte_windos_file.txt', 1)) {
       lines.push(line);
     }
 
@@ -155,3 +155,12 @@ describe('File with empty lines with simplified API', function() {
   });
 });
 
+describe('The simplified API with the maximum line length limited', function() {
+  it('should return 6 instead of 3 lines', function() {
+    const lines = [];
+    for (let line of readlines.fromFile('./test_data/three_line_file.txt', undefined, 10)) {
+      lines.push(line);
+    }
+    assert.equal(6, lines.length);
+  });
+});

--- a/tests.js
+++ b/tests.js
@@ -293,3 +293,47 @@ describe('The file with two CR-only line breaks', function() {
     assert.ok(entry.done);
   });
 });
+
+describe('With the maximum line length limited', function() {
+  let fd;
+  let stats;
+
+  before(function() {
+    fd = fs.openSync('./test_data/three_line_file.txt', 'r');
+    stats = fs.statSync('./test_data/three_line_file.txt');
+  });
+
+  after(function() {
+    fs.closeSync(fd);
+  });
+
+  it('the three line file should return 6 instead of 3 lines', function() {
+    const lines = [];
+    for (let line of readlines(fd, stats.size, undefined, undefined, 10)) {
+      assert.ok(line.length <= 10);
+      lines.push(line);
+    }
+    assert.equal(6, lines.length);
+  });
+
+  it('the maximum line length can be changed for an iteration', function() {
+    const gen = readlines(fd, stats.size, undefined, undefined, 10);
+    // first line
+    let entry = gen.next();
+    assert.ok(!entry.done);
+    assert.ok(entry.value.length === 10);
+    entry = gen.next();
+    assert.ok(!entry.done);
+    assert.ok(entry.value.length < 10);
+    // second line
+    entry = gen.next(5);
+    assert.ok(!entry.done);
+    assert.ok(entry.value.length === 5);
+    entry = gen.next();
+    assert.ok(!entry.done);
+    assert.ok(entry.value.length === 10);
+    entry = gen.next();
+    assert.ok(!entry.done);
+    assert.ok(entry.value.length < 10);
+  });
+});


### PR DESCRIPTION
Add the parameter `maxLineLength` to the interface.

If the specified maximum length is reached, the line content buffered so far will be returned as if a line break would occur at the reached position. Parsing of the further content will continue for the next yield.