### PR TITLE
fix: Keep compatibility with 0.x versions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,16 +37,31 @@ function _concat(buffOne?: Buffer, buffTwo?: Buffer): Buffer {
 export default function* readlines(
   fd: number,
   filesize: number,
-  {
+  options:
+    | {
+        bufferSize?: number;
+        position?: number;
+        maxLineLength?: number;
+      }
+    | number = {},
+  positionCompat?: number,
+  maxLineLengthCompat?: number,
+): Generator<Buffer> {
+  let {
     bufferSize = 64 * 1024,
     position = 0,
     maxLineLength = Infinity,
-  }: {
-    bufferSize?: number;
-    position?: number;
-    maxLineLength?: number;
-  } = {},
-): Generator<Buffer> {
+  } = options
+    ? typeof options === 'object'
+      ? options
+      : { bufferSize: options }
+    : {};
+  if (positionCompat !== undefined) {
+    position = positionCompat;
+  }
+  if (maxLineLengthCompat !== undefined) {
+    maxLineLength = maxLineLengthCompat;
+  }
   if (maxLineLength <= 0) {
     throw new Error('maxLineLength must be a positive number');
   }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -215,6 +215,15 @@ describe('The three line file', function () {
 
     assert.strictEqual(3, lines.length);
   });
+
+  it('should return 2 lines when the starting position is shifted', function () {
+    const lines = [];
+    for (let line of readlines(fd, stats.size, undefined, 20)) {
+      lines.push(line);
+    }
+
+    assert.strictEqual(2, lines.length);
+  });
 });
 
 describe('File with empty lines', function () {


### PR DESCRIPTION
The breaking change was not announced. A kindness period till the next version?

For your consideration. Not so important after the major version bump.